### PR TITLE
Fix ADMSender.send callback

### DIFF
--- a/lib/push-notifications.js
+++ b/lib/push-notifications.js
@@ -199,14 +199,14 @@ PushNotifications.prototype.send = function (pushId, data, callback) {
       ADMSender.send(AMZmesssage, tempADM, function (err, result) {
         if (err) {
           // No recoverable error
-          done({
+          return done({
             device: 'amazon phone',
             message: err
           });
         }
         if (result.error) {
           // ADM Server error such as InvalidRegistrationId
-          done({
+          return done({
             device: 'amazon phone',
             message: result.error
           });


### PR DESCRIPTION
We need to `return callback` if there is an error to avoid further checkings
in case of `error` `result` is `undefined`
And we get `Cannot read property error of undefined`